### PR TITLE
DM-39838: Some docstring cleanups and add ruff config

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,8 +43,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda install -y -q \
-            "flake8<5" \
-            pytest pytest-flake8 pytest-xdist pytest-openfiles pytest-cov
+            pytest pytest-xdist pytest-openfiles pytest-cov
 
       - name: List installed packages
         shell: bash -l {0}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,3 +9,8 @@ on:
 jobs:
   call-workflow:
     uses: lsst/rubin_workflows/.github/workflows/lint.yaml@main
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: chartboost/ruff-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ pytest_session.txt
 .cache/
 .pytest_cache
 .coverage
+_build.*

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -11,3 +11,7 @@ html_title = project
 html_short_title = project
 doxylink = {}
 exclude_patterns = ["changes/*"]
+
+nitpick_ignore_regex = [
+    ("py:obj", r"sqlalchemy\..*"),
+]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -15,3 +15,7 @@ exclude_patterns = ["changes/*"]
 nitpick_ignore_regex = [
     ("py:obj", r"sqlalchemy\..*"),
 ]
+nitpick_ignore = [
+    ("py:obj", "match"),
+    ("py:obj", "case"),
+]

--- a/doc/lsst.daf.relation/index.rst
+++ b/doc/lsst.daf.relation/index.rst
@@ -174,10 +174,10 @@ The standard approach to designs like this in object oriented programming is the
 This implicitly restricts the set of node tree types to those with methods in the algorithm/engine base class.
 
 In languages with functional programming aspects, a much more direct approach involving enumerated types and pattern-matching syntax is often possible.
-With the introduction of the ``match`` statement in Python 3.10, this now includes Python, and this is the approach taken in here.
-This results in much more readable and concise code than the boilerplate-heavy visitor-pattern alternative, but it comes with a significant drawback: there are no checks (either at runtime or via static type checkers like MyPy) that all necessary ``case`` branches of a ``match`` are present.
+With the introduction of the `match` statement in Python 3.10, this now includes Python, and this is the approach taken in here.
+This results in much more readable and concise code than the boilerplate-heavy visitor-pattern alternative, but it comes with a significant drawback: there are no checks (either at runtime or via static type checkers like MyPy) that all necessary `case` branches of a `match` are present.
 This is in part by design - many algorithms on relation trees can act generically on most operation types, and hence need to only explicitly match one or two - but it requires considerable discipline from algorithm and engine authors to ensure that match logic is correct and well-tested.
-Another (smaller) drawback is that it can occasionally yield code that in other contexts might be considered antipatterns (e.g. `isinstance` is often a good alternative to a single-branch ``match``).
+Another (smaller) drawback is that it can occasionally yield code that in other contexts might be considered antipatterns (e.g. `isinstance` is often a good alternative to a single-branch `match`).
 
 .. _relational algebra: https://en.wikipedia.org/wiki/Relational_algebra
 .. _SQLAlchemy: https://www.sqlalchemy.org/

--- a/doc/lsst.daf.relation/index.rst
+++ b/doc/lsst.daf.relation/index.rst
@@ -62,7 +62,7 @@ Applying an operation to a relation always returns a new relation (unless the op
 `Deduplication` (`UnaryOperation`) / `Relation.without_duplicates`
    Remove duplicate rows.
    This is equivalent to ``SELECT DISTINCT`` in SQL or filtering through `set` or `dict` in Python.
-`Identity` (`Marker`)
+`Identity` (`MarkerRelation`)
    Do nothing.
    This operation never actually appears in `Relation` trees; `Identity.apply`
    always returns the operand relation passed to it.
@@ -93,7 +93,7 @@ Many relation operations involve column expressions, such as the boolean filter 
 These are represented by the `ColumnExpression` (for general scalar-valued expressions), `Predicate` (for boolean expressions), and `ColumnContainer`  (for expressions that hold multiple values) abstract base classes.
 These base classes provide factory methods for all derived classes, making it generally unnecessary to refer to those types directly (except when writing an algorithm or engine that processes a relation tree; see :ref:`lsst.daf.relation-overview-extensibility`).
 Column expression objects can in general support multiple engines; some types are required to be supported by all engines, while others can hold a list of engine types that support them.
-The concrete column expression classes provided by `lsst.daf.relation` are given below, with their factory methods:
+The concrete column expression classes provided by ``lsst.daf.relation`` are given below, with their factory methods:
 
 `ColumnLiteral` / `ColumnExpression.literal`
    A constant scalar, non-boolean Python value.
@@ -174,10 +174,10 @@ The standard approach to designs like this in object oriented programming is the
 This implicitly restricts the set of node tree types to those with methods in the algorithm/engine base class.
 
 In languages with functional programming aspects, a much more direct approach involving enumerated types and pattern-matching syntax is often possible.
-With the introduction of the `match` statement in Python 3.10, this now includes Python, and this is the approach taken in here.
-This results in much more readable and concise code than the boilerplate-heavy visitor-pattern alternative, but it comes with a significant drawback: there are no checks (either at runtime or via static type checkers like MyPy) that all necessary `case` branches of a `match` are present.
+With the introduction of the ``match`` statement in Python 3.10, this now includes Python, and this is the approach taken in here.
+This results in much more readable and concise code than the boilerplate-heavy visitor-pattern alternative, but it comes with a significant drawback: there are no checks (either at runtime or via static type checkers like MyPy) that all necessary ``case`` branches of a ``match`` are present.
 This is in part by design - many algorithms on relation trees can act generically on most operation types, and hence need to only explicitly match one or two - but it requires considerable discipline from algorithm and engine authors to ensure that match logic is correct and well-tested.
-Another (smaller) drawback is that it can occasionally yield code that in other contexts might be considered antipatterns (e.g. `isinstance` is often a good alternative to a single-branch `match`).
+Another (smaller) drawback is that it can occasionally yield code that in other contexts might be considered antipatterns (e.g. `isinstance` is often a good alternative to a single-branch ``match``).
 
 .. _relational algebra: https://en.wikipedia.org/wiki/Relational_algebra
 .. _SQLAlchemy: https://www.sqlalchemy.org/

--- a/doc/lsst.daf.relation/index.rst
+++ b/doc/lsst.daf.relation/index.rst
@@ -62,7 +62,7 @@ Applying an operation to a relation always returns a new relation (unless the op
 `Deduplication` (`UnaryOperation`) / `Relation.without_duplicates`
    Remove duplicate rows.
    This is equivalent to ``SELECT DISTINCT`` in SQL or filtering through `set` or `dict` in Python.
-`Identity` (`MarkerRelation`)
+`Identity` (`UnaryOperation`)
    Do nothing.
    This operation never actually appears in `Relation` trees; `Identity.apply`
    always returns the operand relation passed to it.

--- a/doc/lsst.daf.relation/iteration.rst
+++ b/doc/lsst.daf.relation/iteration.rst
@@ -26,7 +26,7 @@ In particular:
 - `.Materialization` operations gather all rows into a `list` unless they are already in a `dict` or `list` (via `RowIterable.materialized`);
 - `.Slice` operations on a `RowSequence` are computed directly, creating another `RowSequence` (all other slices are lazy).
 
-All other operations provided by the `lsst.daf.relation` package are guaranteed to only iterate once over their targets, and yield results row-by-row.
+All other operations provided by the ``lsst.daf.relation`` package are guaranteed to only iterate once over their targets, and yield results row-by-row.
 Custom unary operations can be supported by implementing `Engine.apply_custom_unary_operation`.
 
 API reference

--- a/doc/lsst.daf.relation/sql.rst
+++ b/doc/lsst.daf.relation/sql.rst
@@ -18,7 +18,7 @@ It assumes the database query optimizer will reorder at least these operations i
 The `Engine.to_executable` method transforms a `.Relation` tree to a SQL ``SELECT`` or ``UNION`` thereof, as represented by `SQLAlchemy`_.
 The engine's payload type is the `Payload` `~dataclasses.dataclass`, which better maps to SQL tables or very simple subqueries that can be used like tables.
 
-Support for custom `.UnaryOperation` subclasses can be added implementing `~lsst.daf.relation.iteration.Engine.apply_custom_unary_operation`.
+Support for custom `.UnaryOperation` subclasses can be added by reimplementing `Engine.to_payload` while delegating to `super` for the standard operation classes.
 
 .. _lsst.daf.relation-sql-logical-columns:
 

--- a/doc/lsst.daf.relation/sql.rst
+++ b/doc/lsst.daf.relation/sql.rst
@@ -15,10 +15,10 @@ Multi-engine relation trees can be executed by a `.Processor` subclass.
 This engine flattens back-to-back `.Join` and `.Chain` operations, and it actually reorders any combination of adjacent `.Join`, `.Selection`, `.Calculation`, and `.Projection` into a single ``SELECT...FROM...WHERE`` statement via the commutation rules for these operations.
 It assumes the database query optimizer will reorder at least these operations itself anyway, so the goal is to keep the query as simple as possible to stay out of its way and aid human readers.
 
-The `Engine.to_executable` method transforms a `.Relation` tree to a SQL ``SELECT`` or ``UNION`` thereof, as represented by `SQLAlchemy_`.
+The `Engine.to_executable` method transforms a `.Relation` tree to a SQL ``SELECT`` or ``UNION`` thereof, as represented by `SQLAlchemy`_.
 The engine's payload type is the `Payload` `~dataclasses.dataclass`, which better maps to SQL tables or very simple subqueries that can be used like tables.
 
-Support for custom `.UnaryOperation` subclasses can be added implementing `Engine.apply_custom_unary_operation`.
+Support for custom `.UnaryOperation` subclasses can be added implementing `~lsst.daf.relation.iteration.Engine.apply_custom_unary_operation`.
 
 .. _lsst.daf.relation-sql-logical-columns:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ convention = "numpy"
 # Docstring at the very first line is not required
 # D200, D205 and D400 all complain if the first sentence of the docstring does
 # not fit on one line.
-add-ignore = ["D107", "D105", "D102", "D100", "D200", "D205", "D400", "D104"]
+add-ignore = ["D107", "D105", "D102", "D100", "D200", "D205", "D400", "D104", "D401"]
 
 [tool.coverage.report]
 show_missing = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,6 @@ dynamic = ["version"]
 [project.optional-dependencies]
 test = [
     "pytest >= 3.2",
-    "flake8 >= 3.7.5",
-    "pytest-flake8 >= 1.0.4",
     "pytest-openfiles >= 0.5.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,3 +98,6 @@ line_length = 110
 
 [tool.lsst_versions]
 write_to = "python/lsst/daf/relation/version.py"
+
+[tool.pytest.ini_options]
+addopts = "--import-mode=importlib"  # Recommended as best practice

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,3 +101,63 @@ write_to = "python/lsst/daf/relation/version.py"
 
 [tool.pytest.ini_options]
 addopts = "--import-mode=importlib"  # Recommended as best practice
+
+[tool.pydocstyle]
+convention = "numpy"
+# Our coding style does not require docstrings for magic methods (D105)
+# Our docstyle documents __init__ at the class level (D107)
+# We allow methods to inherit docstrings and this is not compatible with D102.
+# Docstring at the very first line is not required
+# D200, D205 and D400 all complain if the first sentence of the docstring does
+# not fit on one line.
+add-ignore = ["D107", "D105", "D102", "D100", "D200", "D205", "D400", "D104"]
+
+[tool.coverage.report]
+show_missing = true
+exclude_lines = [
+    "pragma: no cover",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+]
+
+[tool.ruff]
+exclude = [
+    "__init__.py",
+]
+ignore = [
+    "N802",
+    "N803",
+    "N806",
+    "N812",
+    "N815",
+    "N816",
+    "N999",
+    "D107",
+    "D105",
+    "D102",
+    "D104",
+    "D100",
+    "D200",
+    "D205",
+]
+line-length = 110
+select = [
+    "E",  # pycodestyle
+    "F",  # pyflakes
+    "N",  # pep8-naming
+    "W",  # pycodestyle
+    "D",  # pydocstyle
+    "UP",
+]
+target-version = "py310"
+extend-select = [
+    "RUF100", # Warn about unused noqa
+]
+
+[tool.ruff.pycodestyle]
+max-doc-length = 79
+
+[tool.ruff.pydocstyle]
+convention = "numpy"

--- a/python/lsst/daf/relation/_binary_operation.py
+++ b/python/lsst/daf/relation/_binary_operation.py
@@ -119,7 +119,7 @@ class BinaryOperation(ABC):
         This method provides an opportunity for operations to establish any
         invariants that must be satisfied only when the operation is part of
         a relation.
-        """
+        """  # noqa: D401
         return self
 
     def _finish_apply(self, lhs: Relation, rhs: Relation) -> Relation:
@@ -142,7 +142,7 @@ class BinaryOperation(ABC):
         This method provides an opportunity for operations to change the kind
         of relation produced (the default implementation constructs a
         `BinaryOperationRelation`).
-        """
+        """  # noqa: D401
         from ._operation_relations import BinaryOperationRelation
 
         return BinaryOperationRelation(

--- a/python/lsst/daf/relation/_binary_operation.py
+++ b/python/lsst/daf/relation/_binary_operation.py
@@ -101,8 +101,8 @@ class BinaryOperation(ABC):
     def _begin_apply(self, lhs: Relation, rhs: Relation) -> BinaryOperation:
         """A customization hook for the beginning of operation application.
 
-        Parameter
-        ---------
+        Parameters
+        ----------
         lhs : `Relation`
             One relation the operation should act on.
         rhs : `Relation`

--- a/python/lsst/daf/relation/_columns/_container.py
+++ b/python/lsst/daf/relation/_columns/_container.py
@@ -50,7 +50,7 @@ class ColumnContainer(ABC):
     `ColumnContainer` inheritance is closed to the types already provided by
     this package.  These concrete types can all be constructed via factory
     methods on `ColumnContainer` itself, so the derived types themselves only
-    need to be referenced when writing `match` expressions that process an
+    need to be referenced when writing ``match`` expressions that process an
     expression tree.  See :ref:`lsst.daf.relation-overview-extensibility` for
     rationale and details.
     """

--- a/python/lsst/daf/relation/_columns/_container.py
+++ b/python/lsst/daf/relation/_columns/_container.py
@@ -50,7 +50,7 @@ class ColumnContainer(ABC):
     `ColumnContainer` inheritance is closed to the types already provided by
     this package.  These concrete types can all be constructed via factory
     methods on `ColumnContainer` itself, so the derived types themselves only
-    need to be referenced when writing ``match`` expressions that process an
+    need to be referenced when writing `match` expressions that process an
     expression tree.  See :ref:`lsst.daf.relation-overview-extensibility` for
     rationale and details.
     """

--- a/python/lsst/daf/relation/_columns/_expression.py
+++ b/python/lsst/daf/relation/_columns/_expression.py
@@ -53,7 +53,7 @@ class ColumnExpression(ABC):
     the `ColumnFunction` class and an `Engine` that knows how to interpret its
     `~ColumnFunction.name` value.  These concrete types can all be constructed
     via factory methods on `ColumnExpression` itself, so the derived types
-    themselves only need to be referenced when writing ``match`` expressions
+    themselves only need to be referenced when writing `match` expressions
     that process an expression tree.  See
     :ref:`lsst.daf.relation-overview-extensibility` for rationale and details.
     """

--- a/python/lsst/daf/relation/_columns/_expression.py
+++ b/python/lsst/daf/relation/_columns/_expression.py
@@ -53,8 +53,8 @@ class ColumnExpression(ABC):
     the `ColumnFunction` class and an `Engine` that knows how to interpret its
     `~ColumnFunction.name` value.  These concrete types can all be constructed
     via factory methods on `ColumnExpression` itself, so the derived types
-    themselves only need to be referenced when writing `match` expressions that
-    process an expression tree.  See
+    themselves only need to be referenced when writing ``match`` expressions
+    that process an expression tree.  See
     :ref:`lsst.daf.relation-overview-extensibility` for rationale and details.
     """
 
@@ -70,7 +70,7 @@ class ColumnExpression(ABC):
 
     Interpretation of this attribute is up to the `Engine` or other algorithms
     that operate on the expression tree; it is ignored by all code in the
-    `lsst.daf.relation` package.
+    ``lsst.daf.relation`` package.
     """
 
     @property

--- a/python/lsst/daf/relation/_columns/_predicate.py
+++ b/python/lsst/daf/relation/_columns/_predicate.py
@@ -53,7 +53,7 @@ class Predicate(ABC):
     `~PredicateFunction.name` value.  These concrete types can all be
     constructed via factory methods on `Predicate` itself, `ColumnExpression`,
     or `ColumnContainer`, so the derived types themselves only need to be
-    referenced when writing `match` expressions that process an expression
+    referenced when writing ``match`` expressions that process an expression
     tree.  See :ref:`lsst.daf.relation-overview-extensibility` for rationale
     and details.
     """

--- a/python/lsst/daf/relation/_columns/_predicate.py
+++ b/python/lsst/daf/relation/_columns/_predicate.py
@@ -53,7 +53,7 @@ class Predicate(ABC):
     `~PredicateFunction.name` value.  These concrete types can all be
     constructed via factory methods on `Predicate` itself, `ColumnExpression`,
     or `ColumnContainer`, so the derived types themselves only need to be
-    referenced when writing ``match`` expressions that process an expression
+    referenced when writing `match` expressions that process an expression
     tree.  See :ref:`lsst.daf.relation-overview-extensibility` for rationale
     and details.
     """

--- a/python/lsst/daf/relation/_engine.py
+++ b/python/lsst/daf/relation/_engine.py
@@ -225,7 +225,7 @@ class Engine(Hashable):
         ----------
         columns : `~collections.abc.Set` [ `ColumnTag` ]
             The columns in this relation.
-        messages : `~collections.abc.Sequence [ `str` ]
+        messages : `~collections.abc.Sequence` [ `str` ]
             One or more messages explaining why the relation has no rows.
         name : `str`, optional
             Name used to identify and reconstruct this relation.

--- a/python/lsst/daf/relation/_engine.py
+++ b/python/lsst/daf/relation/_engine.py
@@ -292,7 +292,7 @@ class Engine(Hashable):
         to actually create a `UnaryOperationRelation` and perform final
         simplification and checks.  This is all the default implementation
         does.
-        """
+        """  # noqa: D401
         return operation._finish_apply(target)
 
     def append_binary(self, operation: BinaryOperation, lhs: Relation, rhs: Relation) -> Relation:
@@ -325,7 +325,7 @@ class Engine(Hashable):
         to actually create a `UnaryOperationRelation` and perform final
         simplification and checks.  This is all the default implementation
         does.
-        """
+        """  # noqa: D401
         return operation._finish_apply(lhs, rhs)
 
     def backtrack_unary(

--- a/python/lsst/daf/relation/_engine.py
+++ b/python/lsst/daf/relation/_engine.py
@@ -367,7 +367,7 @@ class Engine(Hashable):
 
 @dataclasses.dataclass(repr=False, eq=False, kw_only=True)
 class GenericConcreteEngine(Engine, Generic[_F]):
-    """An implementation-focused base class for `Engine` objects
+    """An implementation-focused base class for `Engine` objects.
 
     This class provides common functionality for the provided `iteration` and
     `sql` engines.  It may be used in external engine implementations as well.

--- a/python/lsst/daf/relation/_leaf_relation.py
+++ b/python/lsst/daf/relation/_leaf_relation.py
@@ -108,7 +108,7 @@ class LeafRelation(BaseRelation):
             The engine that is responsible for interpreting this relation.
         columns : `~collections.abc.Set` [ `ColumnTag` ]
             The columns in this relation.
-        messages : `~collections.abc.Sequence [ `str` ]
+        messages : `~collections.abc.Sequence` [ `str` ]
             One or more messages explaining why the relation has no rows.
         name : `str`, optional
             Name used to identify and reconstruct this relation.

--- a/python/lsst/daf/relation/_operations/_chain.py
+++ b/python/lsst/daf/relation/_operations/_chain.py
@@ -39,7 +39,8 @@ if TYPE_CHECKING:
 @dataclasses.dataclass(frozen=True)
 class Chain(BinaryOperation):
     """A relation operation that concatenates the rows of a pair of relations
-    with the same columns."""
+    with the same columns.
+    """
 
     def __str__(self) -> str:
         return "∪"

--- a/python/lsst/daf/relation/_operations/_join.py
+++ b/python/lsst/daf/relation/_operations/_join.py
@@ -221,9 +221,6 @@ class Join(BinaryOperation):
         ColumnError
             Raised if the given predicate requires columns not present in
             ``lhs`` or ``rhs``.
-        RowOrderError
-            Raised if ``lhs`` or ``rhs`` is unnecessarily ordered; see
-            `Relation.expect_unordered`.
 
         Notes
         -----

--- a/python/lsst/daf/relation/_operations/_sort.py
+++ b/python/lsst/daf/relation/_operations/_sort.py
@@ -43,6 +43,8 @@ if TYPE_CHECKING:
 
 @dataclasses.dataclass
 class SortTerm:
+    """Sort expression and indication of sort direction."""
+
     expression: ColumnExpression
     ascending: bool = True
 

--- a/python/lsst/daf/relation/_processor.py
+++ b/python/lsst/daf/relation/_processor.py
@@ -86,7 +86,7 @@ class Processor(ABC):
             A version of the relation tree in which any relation with a
             `Transfer` operation has a copy of the original `Transfer` that
             has a `~Relation.payload` attached.
-        """
+        """  # noqa: D401
         return self._process_recursive(relation, materialize_as=None)[0]
 
     @abstractmethod
@@ -115,7 +115,7 @@ class Processor(ABC):
         -------
         payload
             Payload for this relation in the ``destination`` engine.
-        """
+        """  # noqa: D401
         raise NotImplementedError()
 
     @abstractmethod
@@ -140,7 +140,7 @@ class Processor(ABC):
         -------
         payload
             Payload for this relation that should be cached.
-        """
+        """  # noqa: D401
         raise NotImplementedError()
 
     def _process_recursive(self, original: Relation, materialize_as: str | None) -> tuple[Relation, bool]:

--- a/python/lsst/daf/relation/_relation.py
+++ b/python/lsst/daf/relation/_relation.py
@@ -247,13 +247,10 @@ class Relation(Protocol):
         Returns
         -------
         relation : `Relation`
-            New relation with all rows from both relations.  If the engine
-            preserves order for chains, all
-            rows from ``self`` will appear before all rows from ``rhs``, in
-            their original order.  This method never returns an operand
-            directly, even if the other has ``max_rows==0``, as it is assumed
-            that even relations with no rows are useful to preserve in the tree
-            for `diagnostics <Diagnostics>`.
+            New relation with all rows from both relations. This method never
+            returns an operand directly, even if the other has ``max_rows==0``,
+            as it is assumed that even relations with no rows are useful to
+            preserve in the tree for `diagnostics <Diagnostics>`.
 
         Raises
         ------

--- a/python/lsst/daf/relation/_relation.py
+++ b/python/lsst/daf/relation/_relation.py
@@ -150,11 +150,11 @@ class Relation(Protocol):
 
     @abstractmethod
     def attach_payload(self, payload: Any) -> None:
-        """Attach an engine-specific `payload` to this relation.
+        """Attach an engine-specific ``payload`` to this relation.
 
         This method may be called exactly once on a `Relation` instance that
-        was not initialized with a `payload`, despite the fact that `Relation`
-        objects are otherwise considered immutable.
+        was not initialized with a ``payload``, despite the fact that
+        `Relation` objects are otherwise considered immutable.
 
         Parameters
         ----------
@@ -248,7 +248,7 @@ class Relation(Protocol):
         -------
         relation : `Relation`
             New relation with all rows from both relations.  If the engine
-            `preserves order <Engine.preserves_chain_order>` for chains, all
+            preserves order for chains, all
             rows from ``self`` will appear before all rows from ``rhs``, in
             their original order.  This method never returns an operand
             directly, even if the other has ``max_rows==0``, as it is assumed
@@ -261,9 +261,6 @@ class Relation(Protocol):
             Raised if the two relations do not have the same columns.
         EngineError
             Raised if the two relations do not have the same engine.
-        RowOrderError
-            Raised if ``self`` or ``rhs`` is unnecessarily ordered; see
-            `expect_unordered`.
         """
         raise NotImplementedError()
 
@@ -367,9 +364,6 @@ class Relation(Protocol):
             Raised if it was impossible to insert this operation in
             ``rhs.engine`` via backtracks or transfers on ``self``, or if the
             predicate was not supported by the engine.
-        RowOrderError
-            Raised if ``self`` or ``rhs`` is unnecessarily ordered; see
-            `expect_unordered`.
 
         Notes
         -----
@@ -670,7 +664,7 @@ class BaseRelation:
     This class provides method implementations for much of the `Relation`
     interface and is actually inherited from (unlike `Relation` itself) by all
     concrete relations.  It should only be used outside of the
-    `lsst.daf.relation` package when needed for `isinstance` checks.
+    ``lsst.daf.relation`` package when needed for `isinstance` checks.
     """
 
     def __init_subclass__(cls) -> None:

--- a/python/lsst/daf/relation/_relation.py
+++ b/python/lsst/daf/relation/_relation.py
@@ -664,7 +664,7 @@ def _copy_relation_docs(method: _M) -> _M:
     also want those docs to appear in the concrete derived classes, and that
     means we need to put them on the `BaseRelation` class so they can be
     inherited.
-    """
+    """  # noqa: D401
     method.__doc__ = getattr(Relation, method.__name__).__doc__
     return method
 

--- a/python/lsst/daf/relation/_relation.py
+++ b/python/lsst/daf/relation/_relation.py
@@ -413,9 +413,6 @@ class Relation(Protocol):
             materialization (in which case the given name or name prefix will
             be ignored).
 
-        Raises
-        ------
-
         See Also
         --------
         Processor.materialize
@@ -646,9 +643,6 @@ class Relation(Protocol):
         relation : `Relation`
             New relation in the given engine.  Will be ``self`` if
             ``self.engine == destination``.
-
-        Raises
-        ------
         """
         raise NotImplementedError()
 

--- a/python/lsst/daf/relation/_unary_operation.py
+++ b/python/lsst/daf/relation/_unary_operation.py
@@ -245,8 +245,8 @@ class UnaryOperation(ABC):
     ) -> tuple[UnaryOperation, Engine]:
         """A customization hook for the beginning of operation application.
 
-        Parameter
-        ---------
+        Parameters
+        ----------
         target : `Relation`
             Relation the operation should act on, at least conceptually.  Later
             logic may actually apply the operation upstream of this relation,

--- a/python/lsst/daf/relation/_unary_operation.py
+++ b/python/lsst/daf/relation/_unary_operation.py
@@ -272,7 +272,7 @@ class UnaryOperation(ABC):
         a relation.  Implementations can also return an `Identity` instance
         when they can determine that the operation will do nothing when applied
         to the given target.
-        """
+        """  # noqa: D401
         return self, preferred_engine if preferred_engine is not None else target.engine
 
     def _finish_apply(self, target: Relation) -> Relation:
@@ -297,7 +297,7 @@ class UnaryOperation(ABC):
         implementation does, via calls to `simplify`) and change the kind of
         relation produced (the default implementation constructs a
         `UnaryOperationRelation`).
-        """
+        """  # noqa: D401
         from ._operation_relations import UnaryOperationRelation
 
         match target:

--- a/python/lsst/daf/relation/iteration/_engine.py
+++ b/python/lsst/daf/relation/iteration/_engine.py
@@ -286,7 +286,7 @@ class Engine(GenericConcreteEngine[Callable[..., Any]]):
                     arg_callables = [self.convert_column_expression(arg) for arg in args]
                     # MyPy doesn't see 'function' as not-None for some reason.
                     return lambda row: function(*[c(row) for c in arg_callables])  # type: ignore
-                first, *rest = [self.convert_column_expression(arg) for arg in args]
+                first, *rest = (self.convert_column_expression(arg) for arg in args)
                 return lambda row: getattr(first(row), name)(*[r(row) for r in rest])
         raise AssertionError("matches should be exhaustive and all branches should return")
 
@@ -339,7 +339,7 @@ class Engine(GenericConcreteEngine[Callable[..., Any]]):
                     # MyPy doesn't see 'function' as not-None in the capture
                     # for some reason.
                     return lambda row: function(*[c(row) for c in arg_callables])  # type: ignore
-                first, *rest = [self.convert_column_expression(arg) for arg in args]
+                first, *rest = (self.convert_column_expression(arg) for arg in args)
                 return lambda row: getattr(first(row), name)(*[r(row) for r in rest])
             case LogicalAnd(operands=operands):
                 operand_callables = [self.convert_predicate(arg) for arg in operands]

--- a/python/lsst/daf/relation/iteration/_row_iterable.py
+++ b/python/lsst/daf/relation/iteration/_row_iterable.py
@@ -120,7 +120,7 @@ class MaterializedRowIterable(RowIterable):
 
 
 class RowMapping(MaterializedRowIterable):
-    """A `RowIterable` backed by a `~collections.abc.Mapping`
+    """A `RowIterable` backed by a `~collections.abc.Mapping`.
 
     Parameters
     ----------
@@ -152,7 +152,7 @@ class RowMapping(MaterializedRowIterable):
 
 
 class RowSequence(MaterializedRowIterable):
-    """A `RowIterable` backed by a `~collections.abc.Sequence`
+    """A `RowIterable` backed by a `~collections.abc.Sequence`.
 
     Parameters
     ----------

--- a/python/lsst/daf/relation/sql/_engine.py
+++ b/python/lsst/daf/relation/sql/_engine.py
@@ -226,7 +226,7 @@ class Engine(
         -------
         appended : `Select`
             Conformed relation tree that includes the given operation.
-        """
+        """  # noqa: D401
         match operation:
             case Calculation(tag=tag):
                 if select.is_compound:
@@ -347,7 +347,7 @@ class Engine(
         -------
         appended : `Select`
             Conformed relation tree that includes the given operation.
-        """
+        """  # noqa: D401
         if lhs.has_sort and not lhs.has_slice:
             raise RelationalAlgebraError(
                 f"Applying binary operation {operation} to relation {lhs} will not preserve row order."
@@ -557,7 +557,7 @@ class Engine(
         relation types managed by `Select`, and `Chain` operations nested
         directly as the `skip_to` target of a `Select`.  It delegates to
         `to_payload` for all other relation types.
-        """
+        """  # noqa: D401
         columns_available: Mapping[ColumnTag, _L] | None = None
         executable: sqlalchemy.sql.Select | sqlalchemy.sql.CompoundSelect
         match select.skip_to:
@@ -614,7 +614,7 @@ class Engine(
         payload : `Payload`
             Struct containing a SQLAlchemy represenation of a simple ``SELECT``
             query.
-        """
+        """  # noqa: D401
         assert relation.engine == self, "Should be guaranteed by callers."
         if relation.payload is not None:  # Should cover all LeafRelations
             return relation.payload

--- a/python/lsst/daf/relation/sql/_select.py
+++ b/python/lsst/daf/relation/sql/_select.py
@@ -134,7 +134,8 @@ class Select(MarkerRelation):
     @property
     def has_sort(self) -> bool:
         """Whether there is a `Sort` between `skip_to` and `target`.
-        (`bool`)"""
+        (`bool`).
+        """
         return bool(self.sort.terms)
 
     @property
@@ -154,7 +155,8 @@ class Select(MarkerRelation):
     @property
     def has_slice(self) -> bool:
         """Whether there is a `Slice` between `skip_to` and `target`
-        (`bool`)."""
+        (`bool`).
+        """
         return bool(self.slice.start) or self.slice.stop is not None
 
     def reapply(self, target: Relation, payload: Any | None = None) -> Select:

--- a/python/lsst/daf/relation/tests.py
+++ b/python/lsst/daf/relation/tests.py
@@ -35,6 +35,7 @@ try:
 except ImportError:
     # MyPy doesn't like this trick.
     def sql_dialect() -> Any:  # type: ignore
+        """Mock sql dialect."""
         raise unittest.SkipTest("sqlalchemy SQLite dialect not available")
 
 

--- a/tests/test_column_expressions.py
+++ b/tests/test_column_expressions.py
@@ -41,6 +41,8 @@ from lsst.daf.relation import (
 
 
 class ColumnExpressionTestCase(tests.RelationTestCase):
+    """Test column expressions."""
+
     def test_operator_function(self) -> None:
         """Test ColumnFunction via its constructor and a name found in the
         `operator` module.

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -91,7 +91,8 @@ class DiagnosticsTestCase(tests.RelationTestCase):
 
     def test_executed_leaf(self) -> None:
         """Test Diagnostics on LeafRelations with max_rows != 0 and
-        empty-invariant operations acting on them."""
+        empty-invariant operations acting on them.
+        """
         engine = EmptyLookupEngine()
         leaf = engine.make_leaf("leaf")
         self.assertEqual(

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -61,7 +61,8 @@ class JoinTestCase(tests.RelationTestCase):
 
     def test_attributes(self) -> None:
         """Check that all Relation and PartialJoin attributes have the expected
-        values."""
+        values.
+        """
         relation = self.leaf_1.join(self.leaf_2)
         assert isinstance(relation, BinaryOperationRelation)
         self.assertEqual(relation.columns, {self.a, self.b, self.c})

--- a/tests/test_leaf_relation.py
+++ b/tests/test_leaf_relation.py
@@ -70,7 +70,8 @@ class LeafRelationTestCase(unittest.TestCase):
 
     def test_join_identity(self) -> None:
         """Test `LeafRelation.make_join_identity and the iteration engine's
-        get_join_identity_payload."""
+        get_join_identity_payload.
+        """
         engine = iteration.Engine()
         join_identity_leaf = LeafRelation.make_join_identity(engine)
         self.assertEqual(join_identity_leaf, LeafRelation.make_join_identity(engine))
@@ -87,7 +88,8 @@ class LeafRelationTestCase(unittest.TestCase):
 
     def test_doomed(self) -> None:
         """Test `LeafRelation.make_doomed and the iteration engine's
-        get_doomed_payload."""
+        get_doomed_payload.
+        """
         engine = iteration.Engine()
         doomed_leaf = LeafRelation.make_doomed(engine, {self.a, self.b}, ["doomed 1"])
         self.assertEqual(

--- a/tests/test_sql_engine.py
+++ b/tests/test_sql_engine.py
@@ -74,6 +74,8 @@ def _make_leaf(
 
 
 class SqlEngineTestCase(tests.RelationTestCase):
+    """Test the SQL engine."""
+
     def setUp(self):
         self.maxDiff = None
 


### PR DESCRIPTION
Still 269 warnings to go. Some of them are references to private methods that I can't yet make public.

Some of them are difficult for me to understand:

```
python/lsst/daf/relation/_relation.py:docstring of lsst.daf.relation._relation.BaseRelation.without_duplicates:41: WARNING: py:obj reference target not found: Relation
```

For example the above looks like an error resolving `Relation` but if I go to the built docs for `BaseRelation.without_duplicates` there are no link problems as far as I can tell.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
