### PR TITLE
Remove RUF100 check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,9 +154,6 @@ select = [
     "D",  # pydocstyle
     "UP",
 ]
-extend-select = [
-    "RUF100", # Warn about unused noqa
-]
 
 [tool.ruff.lint.pycodestyle]
 max-doc-length = 79


### PR DESCRIPTION
This check is causing us some problems at the moment because Rubin-env 8 uses a much older version of ruff than rubin-env 9 and the newer ruff has some fixes in it that mean that some noqa annotations are no longer required.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
